### PR TITLE
add left:prev::right:next kbd shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dom-closest": "^0.2.0",
     "es6-promise": "^3.0.2",
     "mess": "^0.1.2",
+    "mousetrap": "^1.5.3",
     "object-assign": "^3.0.0",
     "route-matcher": "^0.1.0",
     "tiny-emitter": "^1.0.0"

--- a/source/js/views/player.js
+++ b/source/js/views/player.js
@@ -2,6 +2,7 @@ import playlist from '../services/playlist'
 import player from '../lib/player'
 import events from 'pub-sub'
 import $ from '$'
+import mousetrap from 'mousetrap'
 
 let artist = document.querySelector('.js-player-artist')
 let title = document.querySelector('.js-player-title')
@@ -62,4 +63,12 @@ events.on('player:prev', () => {
 
 player.addEventListener('ended', () => {
   events.emit('player:next')
+})
+
+mousetrap.bind('right', () => {
+  events.emit('player:next')
+})
+
+mousetrap.bind('left', () => {
+  events.emit('player:prev')
 })


### PR DESCRIPTION
Dear sir,

I hope this "pull request" finds you well.

I am enjoying your "Sound Finder" service. I find myself using it frequently.

I noticed there are no keyboard shortcuts for the music player<sup>1</sup>. This, I cannot abide.

I have taken the liberty of "forking" your project to add support for going backwards and forwards between musical tracks.

- :arrow_left: emits `player:prev`
- :arrow_right: emits `player:next`

After some observation, it would seem my additions to your project are operating as hoped.  The key bindings only get called once. I tested going back and forth between different people's players in the interface. I encountered no errors, bugs, or other issues.

I hope you will consider accepting this contribution which I submit to you in good faith.

Thank you for your time.

Yours respectfully,

N. Goldman

---

(1) Paul C. Pederson, "add keyboard shortcuts for player," *sound-finder* (Portland: Github, 2016), #13.